### PR TITLE
Add solar.py back to TESTS

### DIFF
--- a/TESTS
+++ b/TESTS
@@ -1,3 +1,4 @@
+solar/solar.py
 solar/sens_chart.py
 solar/season.py
 solar/npod_trade.py


### PR DESCRIPTION
Reverts convexengineering/solar#33

@mjburton11 It only fails on the `Npods=5` solve on those machines, so in hindsight I could have commented that out instead of removing the whole file from TESTS.